### PR TITLE
Changed msb/lsb constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.0.7] - TBD
 ### Changed
 - Deprecate Uuid.parse() in favor of Uuid.fromString(), which returns a non-null Uuid or throws an error for an invalid string, in line with Java's UUID.fromString().
+- `uuidOf(msb: Long, lsb: Long)` function (#33)
 
 ## [0.0.6] - 2019-11-21
 ### Changed
@@ -24,7 +25,7 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ### Changed
 - Kotlin version to 1.3.50 (#54)
 ### Deprecated
-- no-args constructor in favor of `uuid4` (#42)
+- no-args constructor in favor of `uuid4()` (#42)
 
 ## [0.0.3] - 2019-06-20
 ### Added

--- a/src/commonMain/kotlin/uuid.kt
+++ b/src/commonMain/kotlin/uuid.kt
@@ -12,26 +12,6 @@ internal const val UUID_STRING_LENGTH = 36
 public typealias UUID = Uuid
 
 /**
- * Construct new [UUID] instance using the given data.
- *
- * @param msb The 64 most significant bits of the [UUID].
- * @param lsb The 64 least significant bits of the [UUID].
- */
-// @SinceKotlin("1.x")
-@Suppress("FunctionName")
-public fun Uuid(msb: Long, lsb: Long): Uuid =
-    Uuid(ByteArray(UUID_BYTES).also { bytes ->
-        (7 downTo 0).fold(msb) { x, i ->
-            bytes[i] = (x and 0xff).toByte()
-            x shr 8
-        }
-        (15 downTo 8).fold(lsb) { x, i ->
-            bytes[i] = (x and 0xff).toByte()
-            x shr 8
-        }
-    })
-
-/**
  * A v4 RFC4122 UUID
  *
  * @property uuid The underlying UUID bytes
@@ -232,6 +212,25 @@ public class Uuid(val uuid: ByteArray) {
      */
     override fun hashCode(): Int = uuid.contentHashCode()
 }
+
+/**
+ * Construct new [Uuid] instance using the given data.
+ *
+ * @param msb The 64 most significant bits of the [Uuid].
+ * @param lsb The 64 least significant bits of the [Uuid].
+ */
+// @SinceKotlin("1.x")
+public fun uuidOf(msb: Long, lsb: Long): Uuid =
+    Uuid(ByteArray(UUID_BYTES).also { bytes ->
+        (7 downTo 0).fold(msb) { x, i ->
+            bytes[i] = (x and 0xff).toByte()
+            x shr 8
+        }
+        (15 downTo 8).fold(lsb) { x, i ->
+            bytes[i] = (x and 0xff).toByte()
+            x shr 8
+        }
+    })
 
 /**
  * Set the [Uuid.version] on this big-endian [ByteArray]. The [Uuid.variant] is

--- a/src/commonTest/kotlin/UuidTest.kt
+++ b/src/commonTest/kotlin/UuidTest.kt
@@ -96,11 +96,11 @@ class UuidTest {
     }
 
     @Test
-    fun uuid_construction_from_msb_and_lsb() {
-        assertEquals("00000000-0000-0000-0000-000000000000", Uuid(0, 0).toString(), "min")
-        assertEquals("00000000-0000-0000-ffff-ffffffffffff", Uuid(0, -1).toString(), "lsb")
-        assertEquals("ffffffff-ffff-ffff-0000-000000000000", Uuid(-1, 0).toString(), "msb")
-        assertEquals("ffffffff-ffff-ffff-ffff-ffffffffffff", Uuid(-1, -1).toString(), "max")
+    fun uuidOf_from_msb_and_lsb() {
+        assertEquals("00000000-0000-0000-0000-000000000000", uuidOf(0, 0).toString(), "min")
+        assertEquals("00000000-0000-0000-ffff-ffffffffffff", uuidOf(0, -1).toString(), "lsb")
+        assertEquals("ffffffff-ffff-ffff-0000-000000000000", uuidOf(-1, 0).toString(), "msb")
+        assertEquals("ffffffff-ffff-ffff-ffff-ffffffffffff", uuidOf(-1, -1).toString(), "max")
     }
 
     @Test


### PR DESCRIPTION
## Fixes or Changes Proposed
- Changed Java compatible constructor to a freestanding function. This is in relation to #29 and the problem that defining constructors for our class is something that hinders us in general from being compatible with different kinds of native implementations. The goal is that we can define the `Uuid` class as a `typealias` in Java but we cannot, for instance, require a `Uuid(data: ByteArray)` constructor since it is already defined and private. There might be the possibility to overwrite this somehow with a freestanding function of the same name but I believe that it is simpler to just go for freestanding functions for everything and stick with the proper naming for them. Should make for a cleaner API overall.
- Changed the latest `CHANGELOG` entries a little.

Please note that this change is not breaking because we never released the `Uuid(msb: Long, lsb: Long)` constructor.

## PR Checklist
- [x] I have added a CHANGELOG.md entry for any noteable changes or fixes.
- [x] I have added test coverage for any new behavior or bug fixes.