### PR TITLE
Go back to Uuid msb/lsb constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ project adheres to [Semantic Versioning](https://semver.org/).
 ## [0.0.7] - TBD
 ### Changed
 - Deprecate Uuid.parse() in favor of Uuid.fromString(), which returns a non-null Uuid or throws an error for an invalid string, in line with Java's UUID.fromString().
-- `uuidOf(msb: Long, lsb: Long)` function (#52)
-- Deprecated `Uuid(msb: Long, lsb: Long)` in favor of `uuidOf` (#64)
+- `Uuid(msb: Long, lsb: Long)` is now a constructor in stead of a free function (#66)
+- Removed empty `Uuid()` constructor (#66)
 
 ## [0.0.6] - 2019-11-21
 ### Changed
@@ -46,8 +46,3 @@ project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.0.1] - 2019-05-13
 - initial release
-
-[Unreleased]: https://github.com/benasher44/uuid/compare/0.0.3...HEAD
-[0.0.3]: https://github.com/benasher44/uuid/compare/0.0.2...0.0.3
-[0.0.2]: https://github.com/benasher44/uuid/compare/0.0.1...0.0.2
-[0.0.1]: https://github.com/benasher44/uuid/releases/tag/0.0.1

--- a/src/commonTest/kotlin/UuidTest.kt
+++ b/src/commonTest/kotlin/UuidTest.kt
@@ -96,11 +96,11 @@ class UuidTest {
     }
 
     @Test
-    fun uuidOf_from_msb_and_lsb() {
-        assertEquals("00000000-0000-0000-0000-000000000000", uuidOf(0, 0).toString(), "min")
-        assertEquals("00000000-0000-0000-ffff-ffffffffffff", uuidOf(0, -1).toString(), "lsb")
-        assertEquals("ffffffff-ffff-ffff-0000-000000000000", uuidOf(-1, 0).toString(), "msb")
-        assertEquals("ffffffff-ffff-ffff-ffff-ffffffffffff", uuidOf(-1, -1).toString(), "max")
+    fun uuid_from_msb_and_lsb() {
+        assertEquals("00000000-0000-0000-0000-000000000000", Uuid(0, 0).toString(), "min")
+        assertEquals("00000000-0000-0000-ffff-ffffffffffff", Uuid(0, -1).toString(), "lsb")
+        assertEquals("ffffffff-ffff-ffff-0000-000000000000", Uuid(-1, 0).toString(), "msb")
+        assertEquals("ffffffff-ffff-ffff-ffff-ffffffffffff", Uuid(-1, -1).toString(), "max")
     }
 
     @Test


### PR DESCRIPTION
## Fixes or Changes Proposed
- This goes back to having a constructor that takes msb and lsb, which turns out to be important for the `expect class` and erasing the Kotlin type on JVM

## PR Checklist
- [x] I have added a CHANGELOG.md entry for any noteable changes or fixes.
- [x] I have added test coverage for any new behavior or bug fixes.
