### PR TITLE
Introduce uuidOf(bytes) and uuidFrom(string)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.0.7] - TBD
+### Added
+- `uuidOf(bytes)` to construct a `Uuid` from a `ByteArray` (#67)
+- `uuidFrom(from)` to construct a `Uuid` from a `String` (#67)
 ### Changed
-- Deprecate Uuid.parse() in favor of Uuid.fromString(), which returns a non-null Uuid or throws an error for an invalid string, in line with Java's UUID.fromString().
+- Deprecate `Uuid.parse()` in favor of ~`Uuid.fromString()`~ (now `uuidFrom()`, which returns a non-null Uuid or throws an error for an invalid string, in line with Java's `UUID.fromString()`. (#59)
 - `Uuid(msb: Long, lsb: Long)` is now a constructor in stead of a free function (#66)
 - Removed empty `Uuid()` constructor (#66)
+- Deprecate `Uuid(bytes)`, which will eventually become `internal` (#67)
 
 ## [0.0.6] - 2019-11-21
 ### Changed
 - Upgrade to Kotlin 1.3.60 (#56)
-
 
 ## [0.0.5] - 2019-09-03
 ### Changed

--- a/src/commonTest/kotlin/UuidTest.kt
+++ b/src/commonTest/kotlin/UuidTest.kt
@@ -36,7 +36,7 @@ class UuidTest {
     @Test
     fun parses_a_UUID_from_a_string() {
         val uuid = uuid4()
-        val uuidFromStr = Uuid.fromString(uuid.toString())
+        val uuidFromStr = uuidFrom(uuid.toString())
         assertEquals(uuid, uuidFromStr)
         // double check hashcode equality, while we're here
         assertEquals(uuid.hashCode(), uuidFromStr.hashCode())
@@ -44,15 +44,15 @@ class UuidTest {
 
     @Test
     fun throws_when_passed_invalid_number_of_bytes() {
-        assertFails { Uuid(ByteArray(17)) }
-        assertFails { Uuid(ByteArray(15)) }
+        assertFails { uuidOf(ByteArray(17)) }
+        assertFails { uuidOf(ByteArray(15)) }
     }
 
     @Test
     fun parsing_throws_when_passed_invalid_length_of_string() {
         assertFailsWith<IllegalArgumentException>(
             message = "Uuid string has invalid length: c480d6ab-cb0c-427b-a9a6",
-            block = { Uuid.fromString("c480d6ab-cb0c-427b-a9a6") }
+            block = { uuidFrom("c480d6ab-cb0c-427b-a9a6") }
         )
     }
 
@@ -60,7 +60,7 @@ class UuidTest {
     fun parsing_throws_when_passed_invalid_format_of_string() {
         assertFailsWith<IllegalArgumentException>(
             message = "Uuid string has invalid format: c480d6abcb0c427ba9a619c5f8a146bd",
-            block = { Uuid.fromString("c480d6abcb0c427ba9a619c5f8a146bd") }
+            block = { uuidFrom("c480d6abcb0c427ba9a619c5f8a146bd") }
         )
     }
 
@@ -68,7 +68,7 @@ class UuidTest {
     fun parsing_throws_when_passed_invalid_characters_in_string() {
         assertFailsWith<IllegalArgumentException>(
             message = "Uuid string has invalid characters ghijklmn-opqr-stuv-wxyz-GHIJKLMNOPQR",
-            block = { Uuid.fromString("ghijklmn-opqr-stuv-wxyz-GHIJKLMNOPQR") }
+            block = { uuidFrom("ghijklmn-opqr-stuv-wxyz-GHIJKLMNOPQR") }
         )
     }
 
@@ -82,7 +82,7 @@ class UuidTest {
 
     @Test
     fun provides_higher_and_lower_bits() {
-        val uuid = Uuid.fromString("c480d6ab-cb0c-427b-a9a6-19c5f8a146bd")
+        val uuid = uuidFrom("c480d6ab-cb0c-427b-a9a6-19c5f8a146bd")
         assertEquals(-6222257497095190851, uuid.leastSignificantBits)
         assertEquals(-4287190811922382213, uuid.mostSignificantBits)
     }
@@ -114,10 +114,10 @@ class UuidTest {
 
     @Test
     fun variants() {
-        assertEquals(0, Uuid.fromString("00000000-0000-0000-0000-000000000000").variant, "Nil or NCS")
-        assertEquals(2, Uuid.fromString("00000000-0000-0000-8000-000000000000").variant, "RFC 4122")
-        assertEquals(6, Uuid.fromString("00000000-0000-0000-c000-000000000000").variant, "Microsoft")
-        assertEquals(7, Uuid.fromString("00000000-0000-0000-e000-000000000000").variant, "Future")
+        assertEquals(0, uuidFrom("00000000-0000-0000-0000-000000000000").variant, "Nil or NCS")
+        assertEquals(2, uuidFrom("00000000-0000-0000-8000-000000000000").variant, "RFC 4122")
+        assertEquals(6, uuidFrom("00000000-0000-0000-c000-000000000000").variant, "Microsoft")
+        assertEquals(7, uuidFrom("00000000-0000-0000-e000-000000000000").variant, "Future")
     }
 
     @Test
@@ -144,22 +144,22 @@ class UuidTest {
 
     @Test
     fun versions() {
-        assertEquals(0, Uuid.fromString("00000000-0000-0000-0000-000000000000").version, "Nil")
-        assertEquals(1, Uuid.fromString("00000000-0000-1000-0000-000000000000").version, "time-based")
-        assertEquals(2, Uuid.fromString("00000000-0000-2000-0000-000000000000").version, "DCE security")
-        assertEquals(3, Uuid.fromString("00000000-0000-3000-0000-000000000000").version, "name-based using MD5 hashing")
-        assertEquals(4, Uuid.fromString("00000000-0000-4000-0000-000000000000").version, "random or pseudo-random")
-        assertEquals(5, Uuid.fromString("00000000-0000-5000-0000-000000000000").version, "name-based using SHA-1 hashing")
+        assertEquals(0, uuidFrom("00000000-0000-0000-0000-000000000000").version, "Nil")
+        assertEquals(1, uuidFrom("00000000-0000-1000-0000-000000000000").version, "time-based")
+        assertEquals(2, uuidFrom("00000000-0000-2000-0000-000000000000").version, "DCE security")
+        assertEquals(3, uuidFrom("00000000-0000-3000-0000-000000000000").version, "name-based using MD5 hashing")
+        assertEquals(4, uuidFrom("00000000-0000-4000-0000-000000000000").version, "random or pseudo-random")
+        assertEquals(5, uuidFrom("00000000-0000-5000-0000-000000000000").version, "name-based using SHA-1 hashing")
 
-        assertEquals(6, Uuid.fromString("00000000-0000-6000-0000-000000000000").version, "future #1")
-        assertEquals(7, Uuid.fromString("00000000-0000-7000-0000-000000000000").version, "future #2")
-        assertEquals(8, Uuid.fromString("00000000-0000-8000-0000-000000000000").version, "future #3")
-        assertEquals(9, Uuid.fromString("00000000-0000-9000-0000-000000000000").version, "future #4")
-        assertEquals(10, Uuid.fromString("00000000-0000-a000-0000-000000000000").version, "future #5")
-        assertEquals(11, Uuid.fromString("00000000-0000-b000-0000-000000000000").version, "future #6")
-        assertEquals(12, Uuid.fromString("00000000-0000-c000-0000-000000000000").version, "future #7")
-        assertEquals(13, Uuid.fromString("00000000-0000-d000-0000-000000000000").version, "future #8")
-        assertEquals(14, Uuid.fromString("00000000-0000-e000-0000-000000000000").version, "future #9")
-        assertEquals(15, Uuid.fromString("00000000-0000-f000-0000-000000000000").version, "future #10")
+        assertEquals(6, uuidFrom("00000000-0000-6000-0000-000000000000").version, "future #1")
+        assertEquals(7, uuidFrom("00000000-0000-7000-0000-000000000000").version, "future #2")
+        assertEquals(8, uuidFrom("00000000-0000-8000-0000-000000000000").version, "future #3")
+        assertEquals(9, uuidFrom("00000000-0000-9000-0000-000000000000").version, "future #4")
+        assertEquals(10, uuidFrom("00000000-0000-a000-0000-000000000000").version, "future #5")
+        assertEquals(11, uuidFrom("00000000-0000-b000-0000-000000000000").version, "future #6")
+        assertEquals(12, uuidFrom("00000000-0000-c000-0000-000000000000").version, "future #7")
+        assertEquals(13, uuidFrom("00000000-0000-d000-0000-000000000000").version, "future #8")
+        assertEquals(14, uuidFrom("00000000-0000-e000-0000-000000000000").version, "future #9")
+        assertEquals(15, uuidFrom("00000000-0000-f000-0000-000000000000").version, "future #10")
     }
 }

--- a/src/commonTest/kotlin/UuidTest.kt
+++ b/src/commonTest/kotlin/UuidTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertNull
 
 class UuidTest {
 
-    private val uuidChars = HashSet(Uuid.uuidChars)
+    private val uuidChars = HashSet(UUID_CHARS)
 
     private fun isValidUuidChar(char: Char) = uuidChars.contains(char)
 
@@ -17,8 +17,8 @@ class UuidTest {
         val uuid = uuid4()
         val uuidString = uuid.toString()
         assertEquals(uuidString.length, UUID_STRING_LENGTH)
-        assertNull(Uuid.hyphenIndices.find { uuidString[it] != '-' })
-        for (range in Uuid.uuidCharRanges) {
+        assertNull(UUID_HYPHEN_INDICES.find { uuidString[it] != '-' })
+        for (range in UUID_CHAR_RANGES) {
             assertNull(range.find { !isValidUuidChar(uuidString[it]) })
         }
     }


### PR DESCRIPTION
## Fixes or Changes Proposed
- Introduce `uuidOf(bytes)`, so `Uuid(bytes)` can become internal
- Introduce `uuidFrom(string)` to prepare for using `java.util.UUID` on JVM
- Lift internal constants out of companion object

## PR Checklist
- [x] I have added a CHANGELOG.md entry for any noteable changes or fixes.
- [x] I have added test coverage for any new behavior or bug fixes.
