### PR TITLE
Changed extension vals to actual vals

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.code.style=official
 kotlin.incremental=true
 
 GROUP=com.benasher44
-VERSION=0.0.8-SNAPSHOT
+VERSION=0.1.0-SNAPSHOT
 
 POM_URL=https://github.com/benasher44/uuid/
 POM_SCM_URL=https://github.com/benasher44/uuid/

--- a/src/commonMain/kotlin/uuid.kt
+++ b/src/commonMain/kotlin/uuid.kt
@@ -43,19 +43,17 @@ public expect class Uuid : Comparable<Uuid> {
      */
     // @SinceKotlin("1.x")
     public constructor(msb: Long, lsb: Long)
+
+    /** The most significant 64 bits of this UUID's 128 bit value. */
+    public val mostSignificantBits: Long
+
+    /** The least significant 64 bits of this UUID's 128 bit value. */
+    public val leastSignificantBits: Long
 }
 
 /** Gets the raw UUID bytes */
 // @SinceKotlin("1.x")
 public expect val Uuid.bytes: ByteArray
-
-/** The most significant 64 bits of this UUID's 128 bit value. */
-// @SinceKotlin("1.x")
-public expect val Uuid.mostSignificantBits: Long
-
-/** The least significant 64 bits of this UUID's 128 bit value. */
-// @SinceKotlin("1.x")
-public expect val Uuid.leastSignificantBits: Long
 
 /**
  * The variant of the [Uuid], determines the interpretation of the bits.


### PR DESCRIPTION
This is an ABI breaking change since we removed the extension functions. Nothing changed from an API perspective. I used this chance and improved a few releated definitions.