### PR TITLE
Have mavenCentral badge link to version list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A Kotlin Multiplatform UUID
 
-![Maven Central](https://img.shields.io/maven-central/v/com.benasher44/uuid.svg?label=mavenCentral%28%29)
+[![Maven Central](https://img.shields.io/maven-central/v/com.benasher44/uuid.svg?label=mavenCentral%28%29)](https://search.maven.org/artifact/com.benasher44/uuid)
 [![Build Status](https://github.com/benasher44/uuid/workflows/master/badge.svg)](https://github.com/benasher44/uuid/actions?query=workflow%3Amaster)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v1.4%20adopted-ff69b4.svg)](CODE_OF_CONDUCT.md)
 


### PR DESCRIPTION
## Fixes or Changes Proposed
> - For convenience, when clicking the `mavenCentral` badge it now takes you to Maven Central version list for project (rather than a page with just the badge image).

## PR Checklist
- [ ] ~I have added a CHANGELOG.md entry for any noteable changes or fixes.~ N/A
- [ ] ~I have added test coverage for any new behavior or bug fixes.~ N/A