### PR TITLE
README : gradle metadata is no more required

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In your build.gradle(.kts):
 - Add `mavenCentral()` to your repositories
 - Add `implementation "com.benasher44:uuid:<version>"` as a dependency in your `commonMain` `sourceSets`.
 
-This library publishes gradle module metadata, so you should have `enableFeaturePreview("GRADLE_METADATA")` in your settings.gradle(.kts).
+This library publishes gradle module metadata. Nothing to do if you use Gradle 6+, but if not, you should have `enableFeaturePreview("GRADLE_METADATA")` in your settings.gradle(.kts).
 
 ### Future Goals
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ In your build.gradle(.kts):
 - Add `mavenCentral()` to your repositories
 - Add `implementation "com.benasher44:uuid:<version>"` as a dependency in your `commonMain` `sourceSets`.
 
-This library publishes gradle module metadata. Nothing to do if you use Gradle 6+, but if not, you should have `enableFeaturePreview("GRADLE_METADATA")` in your settings.gradle(.kts).
+This library publishes gradle module metadata. If you're using Gradle prior to version 6, you should have `enableFeaturePreview("GRADLE_METADATA")` in your settings.gradle(.kts).
 
 ### Future Goals
 


### PR DESCRIPTION
https://kotlinlang.org/docs/migrating-multiplatform-project-to-14.html#simplify-your-build-configuration

In Gradle 6.0 and above, module metadata is used in dependency resolution and included in publications by default. Thus, once you update to such a version, you can remove enableFeaturePreview("GRADLE_METADATA") from the project’s settings.gradle file.

## PR Checklist
- [X] I have added a CHANGELOG.md entry for any noteable changes or fixes.
- [X] I have added test coverage for any new behavior or bug fixes.
