### PR TITLE
Do not try to sign if no signing key is configured

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -142,10 +142,8 @@ signing {
     sign(publishing.publications)
 }
 
-
-
 tasks.withType(Sign) {
-    onlyIf { isReleaseBuild() }
+    onlyIf { isReleaseBuild() && (System.getenv("SIGNING_KEYID") != null) }
 }
 
 tasks.register('publishMac') {


### PR DESCRIPTION
Mainly a small convenience change to make it easier to test locally.