### PR TITLE
Set apiVersion and languageVersion on the JVM for better compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,6 @@ tasks.dokkaHtml {
 }
 
 kotlin {
-    kotlin {
-        coreLibrariesVersion = "1.7.21"
-    }
     targets {
         js(IR) {
             compilations.all {
@@ -76,7 +73,11 @@ kotlin {
     }
 
     sourceSets {
-        val commonMain by getting
+        val commonMain by getting {
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib:1.7.21")
+            }
+        }
         val commonTest by getting {
             dependencies {
                 implementation(kotlin("test"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -87,7 +87,12 @@ kotlin {
         val nonJvmMain by creating { dependsOn(commonMain) }
         val nonJvmTest by creating { dependsOn(commonTest) }
         val jsMain by getting { dependsOn(nonJvmMain) }
-        val wasmMain by getting { dependsOn(nonJvmMain) }
+        val wasmMain by getting {
+            dependsOn(nonJvmMain)
+            dependencies {
+                implementation("org.jetbrains.kotlin:kotlin-stdlib-wasm")
+            }
+        }
         val jsTest by getting { dependsOn(nonJvmTest) }
         val nativeMain by creating { dependsOn(nonJvmMain) }
         val nativeTest by creating { dependsOn(nonJvmTest) }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,9 @@ tasks.dokkaHtml {
 }
 
 kotlin {
+    kotlin {
+        coreLibrariesVersion = "1.7.21"
+    }
     targets {
         js(IR) {
             compilations.all {
@@ -38,6 +41,8 @@ kotlin {
             compilations.all {
                 kotlinOptions {
                     jvmTarget = "1.8"
+                    apiVersion = "1.7"
+                    languageVersion = "1.7"
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ POM_NAME=UUID
 POM_DESCRIPTION=A Kotlin multiplatform implementation of a v4 RFC4122 UUID
 
 org.gradle.jvmargs=-Xmx4g
+
+kotlin.stdlib.default.dependency=false


### PR DESCRIPTION
Follow up from https://github.com/apollographql/apollo-kotlin/issues/5046

Allowing more JVM compatibility gives more time to consumers to upgrade and I think this doesn't have any downsides since the project isn't using any newer Kotlin APIs or feature. The 1.7 there is a bit arbitrary, feel free to tweak as you see fit.

