### PR TITLE
GitHub Actions Use Node 20

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,18 +13,18 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Cache gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Cache konan
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle.kts') }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,18 +9,18 @@ jobs:
     runs-on: ${{matrix.os}}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/actions/wrapper-validation@v3
       - name: Cache gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle.kts') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Cache konan
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.konan
           key: ${{ runner.os }}-gradle-${{ hashFiles('*.gradle.kts') }}


### PR DESCRIPTION
## Fixes or Changes Proposed
GitHub Actions deprecated Node 12 and 16.

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

<img width="2124" alt="Screenshot 2024-05-31 at 22 20 32" src="https://github.com/benasher44/uuid/assets/5770480/168b716b-55b5-4075-9b27-7cbbc1dc8487">

https://github.com/benasher44/uuid/actions/runs/8344856372

### Results
Resolved warnings and succeeded the action.

https://github.com/benasher44/uuid/actions/runs/9319121646

## PR Checklist
- [ ] I have added a CHANGELOG.md entry for any noteable changes or fixes.
- [ ] I have added test coverage for any new behavior or bug fixes.

